### PR TITLE
Display errors with double spaces in the file name of a PDF

### DIFF
--- a/Rekeningsysteem/src/main/java/org/rekeningsysteem/exception/PdfException.java
+++ b/Rekeningsysteem/src/main/java/org/rekeningsysteem/exception/PdfException.java
@@ -1,6 +1,6 @@
 package org.rekeningsysteem.exception;
 
-public class PdfException extends Exception {
+public class PdfException extends RuntimeException {
 
 	private static final long serialVersionUID = 5773190986626550090L;
 

--- a/Rekeningsysteem/src/main/java/org/rekeningsysteem/io/pdf/PdfExporter.java
+++ b/Rekeningsysteem/src/main/java/org/rekeningsysteem/io/pdf/PdfExporter.java
@@ -32,7 +32,6 @@ public class PdfExporter implements FactuurExporter {
 			rekening.accept(this.visitor);
 		}
 		catch (PdfException exception) {
-		  System.out.println("found  pdf exception");
 			throw exception;
 		}
 		catch (Exception exception) {

--- a/Rekeningsysteem/src/main/java/org/rekeningsysteem/io/pdf/PdfExporter.java
+++ b/Rekeningsysteem/src/main/java/org/rekeningsysteem/io/pdf/PdfExporter.java
@@ -4,6 +4,7 @@ import java.io.File;
 
 import org.apache.log4j.Logger;
 import org.rekeningsysteem.data.util.AbstractRekening;
+import org.rekeningsysteem.exception.PdfException;
 import org.rekeningsysteem.io.FactuurExporter;
 
 public class PdfExporter implements FactuurExporter {
@@ -29,6 +30,10 @@ public class PdfExporter implements FactuurExporter {
 		try {
 			this.visitor.setSaveLocation(saveLocation);
 			rekening.accept(this.visitor);
+		}
+		catch (PdfException exception) {
+		  System.out.println("found  pdf exception");
+			throw exception;
 		}
 		catch (Exception exception) {
 			this.logger.error(exception.getMessage(), exception);

--- a/Rekeningsysteem/src/test/java/org/rekeningsysteem/test/integration/AbstractIntegrationTest.java
+++ b/Rekeningsysteem/src/test/java/org/rekeningsysteem/test/integration/AbstractIntegrationTest.java
@@ -18,6 +18,7 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.rekeningsysteem.data.util.AbstractRekening;
 import org.rekeningsysteem.data.util.visitor.RekeningVoidVisitor;
+import org.rekeningsysteem.exception.PdfException;
 import org.rekeningsysteem.io.FactuurExporter;
 import org.rekeningsysteem.io.FactuurLoader;
 import org.rekeningsysteem.io.FactuurSaver;
@@ -57,6 +58,15 @@ public abstract class AbstractIntegrationTest {
 	@Test
 	public void testPdf() {
 		this.exporter.export(this.rekening, this.pdfFile);
+
+		verifyZeroInteractions(this.logger);
+	}
+
+	// PdfException expected due to double spaces in filename
+	@Test(expected = PdfException.class)
+	public void testPdfWithDoubleSpacesInFileName() {
+		File file = new File("src\\test\\resources\\pdf\\File  with double spaces.pdf");
+		this.exporter.export(this.rekening, file);
 
 		verifyZeroInteractions(this.logger);
 	}


### PR DESCRIPTION
When a PDF file is generated with 2 or more consecutive space, a (silent) error is thrown. This appears to be a bug in LaTeX. This PR makes this error visible and gives an appropriate error alert.

![image](https://user-images.githubusercontent.com/5938204/84429763-fe19e280-ac28-11ea-8821-29a160d33454.png)